### PR TITLE
Add missing parens around tuple used to format exception message

### DIFF
--- a/pathlib2.py
+++ b/pathlib2.py
@@ -1251,7 +1251,7 @@ class Path(PurePath):
         if not isinstance(data, six.binary_type):
             raise TypeError(
                 'data must be %s, not %s' %
-                six.binary_type.__class__.__name__, data.__class__.__name__)
+                (six.binary_type.__class__.__name__, data.__class__.__name__))
         with self.open(mode='wb') as f:
             return f.write(data)
 
@@ -1262,7 +1262,7 @@ class Path(PurePath):
         if not isinstance(data, six.text_type):
             raise TypeError(
                 'data must be %s, not %s' %
-                six.text_type.__class__.__name__, data.__class__.__name__)
+                (six.text_type.__class__.__name__, data.__class__.__name__))
         with self.open(mode='w', encoding=encoding, errors=errors) as f:
             return f.write(data)
 

--- a/test_pathlib2.py
+++ b/test_pathlib2.py
@@ -1405,8 +1405,9 @@ class _BasePathTest(object):
         (p / 'fileA').write_bytes(b'abcdefg')
         self.assertEqual((p / 'fileA').read_bytes(), b'abcdefg')
         # check that trying to write str does not truncate the file
-        self.assertRaises(TypeError, (p / 'fileA').write_bytes,
-                          six.u('somestr'))
+        with self.assertRaises(TypeError) as cm:
+            (p / 'fileA').write_bytes(six.u('somestr'))
+        self.assertTrue(str(cm.exception).startswith('data must be'))
         self.assertEqual((p / 'fileA').read_bytes(), b'abcdefg')
 
     def test_read_write_text(self):
@@ -1415,7 +1416,9 @@ class _BasePathTest(object):
         self.assertEqual((p / 'fileA').read_text(
             encoding='utf-8', errors='ignore'), six.u('bcdefg'))
         # check that trying to write bytes does not truncate the file
-        self.assertRaises(TypeError, (p / 'fileA').write_text, b'somebytes')
+        with self.assertRaises(TypeError) as cm:
+            (p / 'fileA').write_text(b'somebytes')
+        self.assertTrue(str(cm.exception).startswith('data must be'))
         self.assertEqual((p / 'fileA').read_text(encoding='latin-1'),
                          six.u('\u00e4bcdefg'))
 


### PR DESCRIPTION
I could only test against Python 2.7 and Python 3.4, tough.