### PR TITLE
fix for Python Numpy 1.10 fromfile()

### DIFF
--- a/pathlib2.py
+++ b/pathlib2.py
@@ -41,6 +41,8 @@ else:
         supports_symlinks = False
         _getfinalpathname = None
 
+if six.PY2:
+    import codecs
 
 __all__ = [
     "PurePath", "PurePosixPath", "PureWindowsPath",
@@ -1321,8 +1323,12 @@ class Path(PurePath):
             raise TypeError(
                 'data must be %s, not %s' %
                 (six.text_type.__class__.__name__, data.__class__.__name__))
-        with self.open(mode='w', encoding=encoding, errors=errors) as f:
-            return f.write(data)
+        if six.PY2:
+            with codecs.open(str(self),'w',encoding=encoding,errors=errors) as f:
+                return f.write(data)
+        else:
+            with self.open(mode='w', encoding=encoding, errors=errors) as f:
+                return f.write(data)
 
     def touch(self, mode=0o666, exist_ok=True):
         """

--- a/pathlib2.py
+++ b/pathlib2.py
@@ -1282,7 +1282,9 @@ class Path(PurePath):
             return io.open(
                 str(self), mode, buffering, encoding, errors, newline,
                 opener=self._opener)
-        else:
+        elif six.PY2:
+            return open(str(self),mode,buffering)
+        else: #python 3.0-3.2
             return io.open(str(self), mode, buffering,
                            encoding, errors, newline)
 

--- a/test_pathlib2.py
+++ b/test_pathlib2.py
@@ -1420,13 +1420,22 @@ class _BasePathTest(object):
     def test_open_common(self):
         p = self.cls(BASE)
         with (p / 'fileA').open('r') as f:
-            self.assertIsInstance(f, io.TextIOBase)
+            if six.PY2:
+                self.assertIsInstance(f,file)
+            else:
+                self.assertIsInstance(f, io.TextIOBase)
             self.assertEqual(f.read(), "this is file A\n")
         with (p / 'fileA').open('rb') as f:
-            self.assertIsInstance(f, io.BufferedIOBase)
+            if six.PY2:
+                self.assertIsInstance(f,file)
+            else:
+                self.assertIsInstance(f, io.BufferedIOBase)
             self.assertEqual(f.read().strip(), b"this is file A")
         with (p / 'fileA').open('rb', buffering=0) as f:
-            self.assertIsInstance(f, io.RawIOBase)
+            if six.PY2:
+                self.assertIsInstance(f,file)
+            else:
+                self.assertIsInstance(f, io.RawIOBase)
             self.assertEqual(f.read().strip(), b"this is file A")
 
     def test_read_write_bytes(self):

--- a/test_pathlib2.py
+++ b/test_pathlib2.py
@@ -52,7 +52,6 @@ def fs_is_case_insensitive(directory):
 
 support.fs_is_case_insensitive = fs_is_case_insensitive
 
-
 class _BaseFlavourTest(object):
 
     def _check_parse_parts(self, arg, expected):


### PR DESCRIPTION
numpy.fromfile() is a critically important function for loading raw binary data in a very fast manner.

Python 2.x with Numpy 1.10 requires NOT to have io.BufferedReader. This patch makes pathlib2 return a traditional file handle for the .open() method on Python 2.x. 

Astropy had to do this too, see lines 387-414 of 
https://github.com/astropy/astropy/blob/master/astropy/io/fits/util.py

This is not a problem for Python 3.4-3.5 with Numpy 1.10, so I left as is.

After future testing I realize this causes an issue with encoding/writing files. Perhaps you have more experience in this area, I didn't want to layer on hacks.

Perhaps for now I will just put in my own user code a if PY2: then open() etc. instead of messing with pathlib2, as Python<3.4 is an edge case for me.