### PR TITLE
non-unicode str input to unicode

### DIFF
--- a/pathlib2.py
+++ b/pathlib2.py
@@ -1315,8 +1315,8 @@ class Path(PurePath):
         """
         Open the file in text mode, write to it, and close the file.
         """
-        if isinstance(data, six.string_types):
-            data = six.u(data) #for Python 2
+        if isinstance(data, six.string_types) and not isinstance(data, six.text_type):
+            data = six.u(data)  # for Python 2
         if not isinstance(data, six.text_type):
             raise TypeError(
                 'data must be %s, not %s' %

--- a/pathlib2.py
+++ b/pathlib2.py
@@ -1315,7 +1315,7 @@ class Path(PurePath):
         """
         Open the file in text mode, write to it, and close the file.
         """
-        if isinstance(data,six.string_types):
+        if isinstance(data,six.string_types) and six.PY2:
             data = unicode(data)
         if not isinstance(data, six.text_type):
             raise TypeError(

--- a/pathlib2.py
+++ b/pathlib2.py
@@ -1315,6 +1315,8 @@ class Path(PurePath):
         """
         Open the file in text mode, write to it, and close the file.
         """
+        if isinstance(data,six.string_types):
+            data = unicode(data)
         if not isinstance(data, six.text_type):
             raise TypeError(
                 'data must be %s, not %s' %

--- a/pathlib2.py
+++ b/pathlib2.py
@@ -836,9 +836,8 @@ class PurePath(object):
     def __eq__(self, other):
         if not isinstance(other, PurePath):
             return NotImplemented
-        return (
-            self._cparts == other._cparts
-            and self._flavour is other._flavour)
+        return (self._cparts == other._cparts and
+                self._flavour is other._flavour)
 
     def __ne__(self, other):
         return not self == other
@@ -851,26 +850,26 @@ class PurePath(object):
             return self._hash
 
     def __lt__(self, other):
-        if (not isinstance(other, PurePath)
-                or self._flavour is not other._flavour):
+        if (not isinstance(other, PurePath) or
+           self._flavour is not other._flavour):
             return NotImplemented
         return self._cparts < other._cparts
 
     def __le__(self, other):
-        if (not isinstance(other, PurePath)
-                or self._flavour is not other._flavour):
+        if (not isinstance(other, PurePath) or
+           self._flavour is not other._flavour):
             return NotImplemented
         return self._cparts <= other._cparts
 
     def __gt__(self, other):
-        if (not isinstance(other, PurePath)
-                or self._flavour is not other._flavour):
+        if (not isinstance(other, PurePath) or
+           self._flavour is not other._flavour):
             return NotImplemented
         return self._cparts > other._cparts
 
     def __ge__(self, other):
-        if (not isinstance(other, PurePath)
-                or self._flavour is not other._flavour):
+        if (not isinstance(other, PurePath) or
+           self._flavour is not other._flavour):
             return NotImplemented
         return self._cparts >= other._cparts
 
@@ -928,8 +927,9 @@ class PurePath(object):
         if not self.name:
             raise ValueError("%r has an empty name" % (self,))
         drv, root, parts = self._flavour.parse_parts((name,))
-        if (not name or name[-1] in [self._flavour.sep, self._flavour.altsep]
-                or drv or root or len(parts) != 1):
+        if (not name or
+           name[-1] in [self._flavour.sep, self._flavour.altsep] or
+           drv or root or len(parts) != 1):
             raise ValueError("Invalid name %r" % (name))
         return self._from_parsed_parts(self._drv, self._root,
                                        self._parts[:-1] + [name])
@@ -1315,7 +1315,8 @@ class Path(PurePath):
         """
         Open the file in text mode, write to it, and close the file.
         """
-        if isinstance(data, six.string_types) and not isinstance(data, six.text_type):
+        if (isinstance(data, six.string_types) and not
+           isinstance(data, six.text_type)):
             data = six.u(data)  # for Python 2
         if not isinstance(data, six.text_type):
             raise TypeError(
@@ -1552,8 +1553,8 @@ class Path(PurePath):
         """ Return a new path with expanded ~ and ~user constructs
         (as returned by os.path.expanduser)
         """
-        if (not (self._drv or self._root)
-                and self._parts and self._parts[0][:1] == '~'):
+        if (not (self._drv or self._root) and
+           self._parts and self._parts[0][:1] == '~'):
             homedir = self._flavour.gethomedir(self._parts[0][1:])
             return self._from_parts([homedir] + self._parts[1:])
 

--- a/pathlib2.py
+++ b/pathlib2.py
@@ -1315,8 +1315,8 @@ class Path(PurePath):
         """
         Open the file in text mode, write to it, and close the file.
         """
-        if isinstance(data,six.string_types) and six.PY2:
-            data = unicode(data)
+        if isinstance(data, six.string_types):
+            data = six.u(data) #for Python 2
         if not isinstance(data, six.text_type):
             raise TypeError(
                 'data must be %s, not %s' %

--- a/test_pathlib2.py
+++ b/test_pathlib2.py
@@ -1446,7 +1446,10 @@ class _BasePathTest(object):
             encoding='utf-8', errors='ignore'), six.u('bcdefg'))
         # check that trying to write bytes does not truncate the file
         with self.assertRaises(TypeError) as cm:
-            (p / 'fileA').write_text(0)
+            if six.PY2:
+                (p / 'fileA').write_text(0)            
+            else:
+                (p / 'fileA').write_text(b'somebytes')
         self.assertTrue(str(cm.exception).startswith('data must be'))
         self.assertEqual((p / 'fileA').read_text(encoding='latin-1'),
                          six.u('\u00e4bcdefg'))

--- a/test_pathlib2.py
+++ b/test_pathlib2.py
@@ -1446,7 +1446,7 @@ class _BasePathTest(object):
             encoding='utf-8', errors='ignore'), six.u('bcdefg'))
         # check that trying to write bytes does not truncate the file
         with self.assertRaises(TypeError) as cm:
-            (p / 'fileA').write_text(b'somebytes')
+            (p / 'fileA').write_text(0)
         self.assertTrue(str(cm.exception).startswith('data must be'))
         self.assertEqual((p / 'fileA').read_text(encoding='latin-1'),
                          six.u('\u00e4bcdefg'))

--- a/test_pathlib2.py
+++ b/test_pathlib2.py
@@ -1226,8 +1226,14 @@ class PurePathTest(_BasePurePathTest, unittest.TestCase):
 
 # Make sure any symbolic links in the base test path are resolved
 BASE = os.path.realpath(TESTFN)
-join = lambda *x: os.path.join(BASE, *x)
-rel_join = lambda *x: os.path.join(TESTFN, *x)
+
+
+def rel_join(*x):
+    return os.path.join(TESTFN, *x)
+
+
+def join(*x):
+    return os.path.join(BASE, *x)
 
 
 def symlink_skip_reason():
@@ -1447,7 +1453,7 @@ class _BasePathTest(object):
         # check that trying to write bytes does not truncate the file
         with self.assertRaises(TypeError) as cm:
             if six.PY2:
-                (p / 'fileA').write_text(0)            
+                (p / 'fileA').write_text(0)
             else:
                 (p / 'fileA').write_text(b'somebytes')
         self.assertTrue(str(cm.exception).startswith('data must be'))


### PR DESCRIPTION
The user will very often want to write plain str() Python 2.7 text to a file. Let's cast non-unicode text to unicode to avoid surprising error.