### PR TITLE
Migrate old deprecated dependency syntax.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Version 2.3.1 (in development)
 - Fix tests for systems where filesystem encoding only supports ascii
   (reported by yurivict, fixed with help of honnibal, see issue #30).
 
+- Use modern setuptools syntax for specifying conditional scandir
+  dependency (see issue #31).
+
 Version 2.3.0
 ^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
         ],
     download_url='https://pypi.python.org/pypi/pathlib2/',
     url='https://pypi.python.org/pypi/pathlib2/',
-    install_requires=['six'],
-    extras_require={
-        ':python_version<"3.5"': ['scandir'],
-        },
+    install_requires=[
+        'six',
+        'scandir;python_version<"3.5"',
+        ],
 )


### PR DESCRIPTION
See issue #31.