### PR TITLE
travis: run tests also with LC_ALL equal to en_US.ascii

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ python:
   - "2.6"
   - "pypy"
   - "pypy3"
+env:
+  - LC_ALL="en_US.utf-8"
+  - LC_ALL="en_US.ascii"
 matrix:
   allow_failures:
   # pypy3 segfaults for some reason
@@ -18,6 +21,7 @@ branches:
   only:
     - develop
 install:
+  - "python -c \"import sys; print(sys.getfilesystemencoding())\""
   - "pip install -r requirements.txt"
   - "if [[ $TRAVIS_PYTHON_VERSION != '3.2' ]]; then pip install pytest-cov; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install pytest; fi"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ History
 Version 2.3.1 (in development)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fix tests for systems where filesystem encoding only supports ascii
+  (reported by yurivict, fixed with help of honnibal, see issue #30).
+
 Version 2.3.0
 ^^^^^^^^^^^^^
 

--- a/test_pathlib2.py
+++ b/test_pathlib2.py
@@ -731,6 +731,10 @@ class _BasePurePathTest(object):
 
     # note: this is a new test not part of upstream
     # test that unicode works on Python 2
+    @unittest.skipIf(
+        six.unichr(0x0100).encode(
+            sys.getfilesystemencoding(), "replace") == b"?",
+        "file system encoding only supports ascii")
     def test_unicode(self):
         self.cls(six.unichr(0x0100))
 


### PR DESCRIPTION
Suggested by @honnibal ; see issue #30.