### PR TITLE
Adding Travis-Ci Support For Arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,26 @@ matrix:
       dist: xenial
     - python: "pypy3"
       dist: xenial
+    - arch: arm64
+      python: "3.7"
+      dist: xenial
+      env: LC_ALL="en_US.utf-8"
+    - arch: arm64
+      python: "3.7"
+      dist: xenial
+      env: LC_ALL="en_US.ascii"
+    - arch: arm64
+      python: "3.6"
+      dist: xenial
+    - arch: arm64
+      python: "3.5"
+      dist: xenial
+    - arch: arm64
+      python: "3.4"
+      dist: xenial
+    - arch: arm64
+      python: "2.7"
+      dist: xenial
   allow_failures:
   # pypy occasionally has some bugs
   - python: "pypy"


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI.